### PR TITLE
add warning to BYOC deployments taking a long time

### DIFF
--- a/samples/n8n/README.md
+++ b/samples/n8n/README.md
@@ -73,7 +73,7 @@ defang compose up
 If you want to deploy to your own cloud account, you can [use Defang BYOC](https://docs.defang.io/docs/tutorials/deploy-to-your-cloud).
 
 > [!WARNING]
-> **Extended deployment time:** This sample creates a managed PostgreSQL database which takes upwards of 20 minutes to provision on first deployment. Subsequent deployments are much faster (2-5 minutes).
+> **Extended deployment time:** This sample creates a managed PostgreSQL database which may take upwards of 20 minutes to provision on first deployment. Subsequent deployments are much faster (2-5 minutes).
 ---
 
 Title: n8n


### PR DESCRIPTION
This project uses a managed Postgres database for BYOC deployments. Managed Postgres, on first deployment, may take a significant amount of time to start. We add this warning to let users know it is expected deployment will be lengthy.
## Samples Checklist
✅ All good!