### PR TITLE
Fix deploy_changed_samples github action parsing URL

### DIFF
--- a/samples/flask/flask/app.py
+++ b/samples/flask/flask/app.py
@@ -12,7 +12,7 @@ def home():
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Testing URL Depolyment Extraction</title>
+    <title>Todo List</title>
 </head>
 <body>
     <h1>Todo List</h1>


### PR DESCRIPTION
Looking at the code and the output, I can see the issue. The regex is capturing the wrong field from the tabular output.

Here an example:
When the regex `DEPLOYMENT_COMPLETED\s*([^\s]+)` matches this line:

```
SERVICE   DEPLOYMENT    STATE                 FQDN                                                       ENDPOINT                                                    STATUS
database  qyeladeof5wu  NOT_SPECIFIED         defangsampletestfaketenant0-database.staging.ecs.internal  defangsampletestfaketenant0-database.staging.ecs.internal   UPDATE_QUEUED  
app       qyeladeof5wu  DEPLOYMENT_COMPLETED  defangsampletestfaketenant0-app.staging.defang.dev         https://defangsampletestfaketenant0-app.staging.defang.dev  BUILD_QUEUED
```

It captures the **FQDN** field (without `https://`) instead of the **ENDPOINT** field (with `https://`):

- Captured: `defangsampletestfaketenant0-app.staging.defang.dev`
- Needed: `https://defangsampletestfaketenant0-app.staging.defang.dev`

Then this check fails:

`if strings.HasPrefix(m[1], "https://") {
    urls = append(urls, m[1])
}`

Fix:
Instead of looking the FQDN col we parse the endpoint which will have the https prefix.

As you see I can repo the bug [here](https://github.com/DefangLabs/samples/actions/runs/20736008873/job/59533276257?pr=563).

## Samples Checklist
✅ All good!