### PR TITLE
missing extends for local development

### DIFF
--- a/samples/fastapi/compose.dev.yaml
+++ b/samples/fastapi/compose.dev.yaml
@@ -1,6 +1,8 @@
 services:
   fastapi:
+    extends:
+      file: compose.yaml
+      service: fastapi
     volumes:
       - ./fastapi:/app
     command: fastapi dev main.py --host 0.0.0.0
-


### PR DESCRIPTION
The compose.dev.yaml was missing the extend from compose.yaml. It could not find the dockerfile to build.
## Samples Checklist
✅ All good!