### PR TITLE
add static site extension to html-css-js sample

### DIFF
--- a/samples/html-css-js/compose.yaml
+++ b/samples/html-css-js/compose.yaml
@@ -19,3 +19,5 @@ services:
         - curl
         - -f
         - http://localhost:8080/
+    x-defang-static-files:
+      folder: /usr/share/nginx/html


### PR DESCRIPTION
Enable static site deployment optimizations for the `html-css-js` sample
## Samples Checklist
- [ ] fix name: in ./samples/defang-provider-handoff/compose.yaml to be 'defang-provider-handoff' (currently '')
 - [ ] add README.md to ./samples/defang-provider-handoff/