### PR TITLE
prefix environment name with "defang-"

### DIFF
--- a/starter-sample/.github/workflows/deploy.yaml
+++ b/starter-sample/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    environment: production
+    environment: defang-production
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/templates/deploy.yaml
+++ b/templates/deploy.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   defang:
     name: Defang ${{ github.event.inputs.action || 'up' }} ${{ github.event.inputs.stack || 'default stack' }}
-    environment: production
+    environment: defang-production
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
environment names are now `defang-$stackname` in order to support ergonomic OIDC policies like `defang-*`