### PR TITLE
Adds job timeout to defang workflow

### DIFF
--- a/starter-sample/.github/workflows/defang.yaml
+++ b/starter-sample/.github/workflows/defang.yaml
@@ -9,6 +9,7 @@ jobs:
   deploy:
     environment: defang-production
     runs-on: ubuntu-latest
+    timeout-minutes: 70
     permissions:
       contents: read
       id-token: write

--- a/templates/defang.yaml
+++ b/templates/defang.yaml
@@ -23,6 +23,7 @@ jobs:
     name: Defang ${{ github.event.inputs.action || 'up' }} ${{ github.event.inputs.stack || 'default stack' }}
     environment: defang-production
     runs-on: ubuntu-latest
+    timeout-minutes: 70
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Introduces a 70-minute timeout to the defang workflow to prevent jobs from running indefinitely.

70 mins was selected because CD timeout at 60 mins and giving 10 mins for the applications to stabilize should be more then enough time. 

Here an example of this problem: https://github.com/KevyVo/mastra-extended/actions/runs/25031097337

Counterpart PR in the portal: https://github.com/DefangLabs/portal/pull/729