### PR TITLE
Add QUEUE_PREFIX to queue configuration for consistent Redis key handling

### DIFF
--- a/samples/mastra-extended/app/src/lib/queue.ts
+++ b/samples/mastra-extended/app/src/lib/queue.ts
@@ -2,6 +2,10 @@ import IORedis from "ioredis";
 import { Queue } from "bullmq";
 
 export const QUEUE_NAME = process.env.QUEUE_NAME ?? "support-sync";
+// Hash-tag wrapping forces every BullMQ key for this queue (wait/active/events/…)
+// onto the same Redis cluster slot, so multi-key Lua scripts don't trip CROSSSLOT
+// on sharded backends like Azure Managed Redis.
+export const QUEUE_PREFIX = `{${QUEUE_NAME}}`;
 
 declare global {
   // eslint-disable-next-line no-var
@@ -29,6 +33,7 @@ export function getSyncQueue() {
   if (!global.syncQueue) {
     global.syncQueue = new Queue(QUEUE_NAME, {
       connection: getRedisConnection(),
+      prefix: QUEUE_PREFIX,
     });
   }
 

--- a/samples/mastra-extended/app/src/worker.ts
+++ b/samples/mastra-extended/app/src/worker.ts
@@ -11,7 +11,7 @@ import {
   startSeedRun,
   updateProcessedItem,
 } from "@/lib/items";
-import { QUEUE_NAME, getRedisConnection, getSyncQueue } from "@/lib/queue";
+import { QUEUE_NAME, QUEUE_PREFIX, getRedisConnection, getSyncQueue } from "@/lib/queue";
 
 type SeedBatchJob = {
   runId: string;
@@ -100,6 +100,7 @@ async function main() {
     {
       connection: getRedisConnection(),
       concurrency: Number(process.env.WORKER_CONCURRENCY ?? 8),
+      prefix: QUEUE_PREFIX,
     },
   );
 


### PR DESCRIPTION
Fixes issues with Azure Redis "Enterprise" SKU which always shards. Similar to #630

Untested
## Samples Checklist
✅ All good!