### PR TITLE
Remove SSL_MODE env var

### DIFF
--- a/samples/crewai/README.md
+++ b/samples/crewai/README.md
@@ -18,26 +18,22 @@ docker compose -f ./compose.local.yaml up --build
 
 ## Configuration
 
-For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration): 
+For this sample, you will need to provide the following [configuration](https://docs.defang.io/docs/concepts/configuration):
 
 > Note that if you are using the 1-click deploy option, you can set these values as secrets in your GitHub repository and the action will automatically deploy them for you.
 
-### `POSTGRES_PASSWORD`     
+### `POSTGRES_PASSWORD`
+
 The password for the Postgres database.
+
 ```bash
 defang config set POSTGRES_PASSWORD
-```
-
-### `SSL_MODE`
-
-The SSL mode for the Postgres database.
-```bash
-defang config set SSL_MODE
 ```
 
 ### `DJANGO_SECRET_KEY`
 
 The secret key for the Django application.
+
 ```bash
 defang config set DJANGO_SECRET_KEY
 ```
@@ -50,6 +46,7 @@ defang config set DJANGO_SECRET_KEY
 ### Defang Playground
 
 Deploy your application to the Defang Playground by opening up your terminal and typing:
+
 ```bash
 defang compose up
 ```

--- a/samples/crewai/compose.yaml
+++ b/samples/crewai/compose.yaml
@@ -43,7 +43,6 @@ services:
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       DJANGO_SECRET_KEY: null
-      SSL_MODE: null
     healthcheck:
       test:
         - CMD
@@ -75,7 +74,6 @@ services:
       REDIS_URL: redis://redis:6379/0
       OPENAI_API_KEY: defang
       DJANGO_SECRET_KEY: null
-      SSL_MODE: null
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
There no reason to have `SSL_MODE` in the require configs if there no mention of it in the code base or interpolation in other env vars. We should either use it or remove it.
## Samples Checklist
✅ All good!