### PR TITLE
fix(self-improving-mastra): bind app to 0.0.0.0 so Fargate health check passes

### DIFF
--- a/samples/self-improving-mastra/todo-app/Dockerfile
+++ b/samples/self-improving-mastra/todo-app/Dockerfile
@@ -27,4 +27,8 @@ COPY --from=builder --chown=nextjs:nodejs /app/lib/schema.sql ./lib/schema.sql
 USER nextjs
 EXPOSE 3000
 
-CMD ["node", "server.js"]
+# Docker/Fargate inject HOSTNAME=<container hostname> at runtime, overriding the
+# ENV above. Next's standalone server binds to $HOSTNAME, so it would listen only
+# on the task's ENI IP and the `curl localhost` container health check would fail.
+# Re-force 0.0.0.0, then `exec` so node stays PID 1 and receives SIGTERM directly.
+CMD ["sh", "-c", "HOSTNAME=0.0.0.0 exec node server.js"]


### PR DESCRIPTION
## Problem

Deploying the `self-improving-mastra` sample to AWS fails: the `app` service's container health check never passes, ECS kills and replaces the task in a loop, and `defang up` exits non-zero with:

```
deployment failed for service "app": TASK_DEACTIVATING Task failed container health checks
```

The app logs `✓ Ready` and even the ALB target reports **healthy** — but the ECS *container* health check (`curl -f http://localhost:3000/api/health`, run inside the task) never connects.

## Root cause

Next.js standalone (`output: "standalone"` → `node server.js`) binds its HTTP server to `process.env.HOSTNAME`. The Dockerfile sets `ENV HOSTNAME=0.0.0.0` to bind all interfaces — but on Fargate the **container runtime injects its own `HOSTNAME`** (the task's private-DNS hostname, e.g. `ip-10-0-97-61.us-west-2.compute.internal`), and that runtime value **overrides the image `ENV`**. So Next binds only to the task's ENI IP:

- ALB health check → hits the ENI IP → **healthy** ✅
- ECS container health check → `curl localhost` → nothing on loopback → **fails** ❌ → task UNHEALTHY → deploy fails

The startup banner in the failing logs confirms it: `- Local: http://ip-10-0-97-61.us-west-2.compute.internal:3000` (a real `0.0.0.0` bind prints `http://localhost:3000`).

This is Next-standalone-specific — it's the only Next.js sample in the repo using standalone output. The others use `next start`, which binds `0.0.0.0` regardless of `HOSTNAME` and is unaffected. The `dev` service passes the identical check because it fronts Next with Caddy, which binds all interfaces.

## Fix

```dockerfile
CMD ["sh", "-c", "HOSTNAME=0.0.0.0 exec node server.js"]
```

Force `HOSTNAME=0.0.0.0` at launch so the runtime-injected value can't win, and `exec` so node replaces the shell — staying **PID 1** and receiving ECS's SIGTERM directly for graceful shutdown (no signal-swallowing shell wrapper).

## Verification

Reproduced and fixed against the **exact failing ECR image**:

| Condition | Bind | `curl localhost:3000/api/health` |
|---|---|---|
| `HOSTNAME=0.0.0.0` (intended) | `0.0.0.0:3000` | `{"ok":true}` |
| `HOSTNAME=ip-10-0-…` (Fargate) | ENI IP only | connection refused |
| **This fix** | `0.0.0.0:3000` | `{"ok":true}` |

Also confirmed node is PID 1 under the fix and exits 0 promptly on SIGTERM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)