### PR TITLE
fix(ci): sync sample templates across the whole push range, not just the tip commit

### DIFF
--- a/.github/workflows/publish-sample-template.yml
+++ b/.github/workflows/publish-sample-template.yml
@@ -15,11 +15,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # Fetch two to see changes in current commit
-          fetch-depth: 2
+          # Full history so the push's "before" SHA is reachable for the diff
+          # below (a push can add several commits at once).
+          fetch-depth: 0
 
       - name: Run Checks
         id: checks
+        env:
+          # Diff the whole push range, not just the tip commit, so every sample
+          # touched anywhere in the push republishes its template.
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
           ./scripts/check-modified-samples.sh > modified.txt
           echo "@@ MODIFIED @@"

--- a/scripts/check-modified-samples.sh
+++ b/scripts/check-modified-samples.sh
@@ -1,12 +1,24 @@
 #!/bin/bash
 
-# This script checks which samples have been created or modified since the last commit and prints a list of them.
+# Lists samples created or modified by the commits this push added to the
+# branch, so their template repos can be republished.
+#
+# We diff across the WHOLE push range (github.event.before .. HEAD), not just
+# the tip commit: a single push can land several commits at once (rebase-merge,
+# or a direct multi-commit push), and every touched sample must sync — not only
+# the one in the last commit. Falls back to HEAD~1 for manual runs or an
+# unknown/first-push before-SHA (all zeros, or not fetched).
+
+before="${BEFORE_SHA:-}"
+zero="0000000000000000000000000000000000000000"
+if [ -z "$before" ] || [ "$before" = "$zero" ] || ! git rev-parse --verify --quiet "${before}^{commit}" > /dev/null 2>&1; then
+    before="HEAD~1"
+fi
 
 for dir in samples/*/; do
-    # Use git diff to check if the directory has been created or modified between the last commit and the commit before it
-    if git diff --name-only --diff-filter=d HEAD~1..HEAD | grep -q "^${dir}"; then
-        # If it has, print the name of the directory
+    # Print the directory if any file under it changed across the push range
+    # (--diff-filter=d excludes pure deletions, which can't be republished).
+    if git diff --name-only --diff-filter=d "${before}..HEAD" | grep -q "^${dir}"; then
         echo "$dir"
     fi
 done
-


### PR DESCRIPTION
## Goal

Guarantee that a sample's template repo (`DefangSamples/sample-<name>-template`) is republished **whenever main moves** and touches that sample.

## Current behavior

`publish-sample-template.yml` runs on every push to main (good, no path filter), but the change-detection in `check-modified-samples.sh` only diffs the **tip commit**:

```bash
git diff --name-only --diff-filter=d HEAD~1..HEAD   # + checkout fetch-depth: 2
```

A single push can add **multiple commits** to main at once — a rebase-merge, or a direct multi-commit push. In those cases only the last commit is inspected, so any sample changed in an earlier commit of the push **silently fails to republish**. Squash-merges (one commit per push) happen to be safe, which is why it's worked so far.

## Fix

Diff the **entire push range** instead of the tip:

- Pass `github.event.before` into the script as `BEFORE_SHA`.
- Diff `${BEFORE_SHA}..HEAD`.
- `fetch-depth: 0` so the before-SHA is reachable.
- Fall back to `HEAD~1` for manual runs or an unknown/first-push before-SHA (empty, all-zeros, or not fetched) — preserves today's behavior in those cases.

Two-file change: `scripts/check-modified-samples.sh` and `.github/workflows/publish-sample-template.yml`.

## Verification

Run locally against real history, simulating a push that landed the last 3 commits:

| Range | Samples detected |
|---|---|
| old `HEAD~1..HEAD` (tip only) | `self-improving-mastra` |
| new `HEAD~3..HEAD` (full push) | `crewai`, `self-improving-mastra` |

So the new logic catches `crewai`, which the old logic would have dropped. Fallbacks (`BEFORE_SHA` unset / all-zeros / bogus) all degrade cleanly to the previous single-commit result, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)